### PR TITLE
Add PR workflow

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -15,6 +15,8 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,3 +34,19 @@ jobs:
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v2
+      - name: Post a comment
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-success: |
+            Hello developer!
+
+            I am a bot and I have built your PR 🦭!
+
+            Your PR has been built and is ready for review.
+            The site is available at: ${{ steps.upload.outputs.artifact_url }}.
+            You can also download the artifact from the Artifacts tab.
+
+            To view the website use `jakyll serve` in your local environment.
+            And then open http://localhost:4000 in your browser.
+
+            Thanks!

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -1,0 +1,34 @@
+name: Build the Jekyll website without deploying
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v2


### PR DESCRIPTION
Adds a GitHub action that should build the website with Jekyll and upload it as an artefact (a zip of a tar) which can be downloaded.   

The problem is that since the urls in the webpage do not respect the base path in the filesystem we need some kind of a server to view the webpage. The easiest is `jekyll serv` which makes it all a bit circular since one could use the same command to build and host the website locally... 